### PR TITLE
Add support for passing poll option to sane

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,11 @@ Watcher.prototype.build = function Watcher_build() {
 
 Watcher.prototype.addWatchDir = function Watcher_addWatchDir(dir) {
   if (this.watched[dir]) return;
-  var watcher = sane(dir);
+
+  var watcher = new sane.Watcher(dir, {
+    poll: !!this.options.poll
+  });
+
   watcher.on('change', this.onFileChanged.bind(this));
   watcher.on('add', this.onFileAdded.bind(this));
   watcher.on('delete', this.onFileDeleted.bind(this));

--- a/tests/index.js
+++ b/tests/index.js
@@ -22,6 +22,19 @@ describe('broccoli-sane-watcher', function (done) {
     rimraf('tests/fixtures', done);
   });
 
+  it('should pass poll option to sane', function (done) {
+    fs.mkdirSync('tests/fixtures/a');
+    var filter = new TestFilter(['tests/fixtures/a'], function () {
+      return 'output';
+    });
+    var builder = new broccoli.Builder(filter);
+    watcher = new Watcher(builder, { poll: true });
+    watcher.sequence.then(function () {
+      assert.ok(watcher.watched['tests/fixtures/a'].polling);
+      done();
+    });
+  });
+
   it('should emit change event when file is added', function (done) {
     fs.mkdirSync('tests/fixtures/a');
     var changes = 0;


### PR DESCRIPTION
This PR adds support for passing the `poll` option on to sane. This effectively adds support for file systems where file system events are not sent, such as mapped file systems on [Vagrant](http://www.vagrantup.com/) boxes.
