### PR TITLE
Throw a pleasant error when attempting to watch missing directories.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var fs             = require('fs');
 var EventEmitter   = require('events').EventEmitter;
 var sane           = require('sane');
 var Promise        = require('rsvp').Promise;
@@ -56,6 +57,10 @@ Watcher.prototype.build = function Watcher_build() {
 
 Watcher.prototype.addWatchDir = function Watcher_addWatchDir(dir) {
   if (this.watched[dir]) return;
+
+  if (!fs.existsSync(dir)) {
+    throw new Error('Attempting to watch missing directory: ' + dir);
+  }
 
   var watcher = new sane.Watcher(dir, {
     poll: !!this.options.poll

--- a/tests/index.js
+++ b/tests/index.js
@@ -84,4 +84,15 @@ describe('broccoli-sane-watcher', function (done) {
       fs.writeFileSync('tests/fixtures/a/file.js');
     });
   });
+
+  it('should emit a pleasant error when attempting to watch a missing directory', function () {
+    var builder = new broccoli.Builder('test/fixtures/b');
+    var watcher = new Watcher(builder)
+    return watcher.sequence
+      .catch(function(error) {
+        var message = error.message;
+
+        assert.equal(message, 'Attempting to watch missing directory: test/fixtures/b');
+      })
+  });
 });


### PR DESCRIPTION
Prior to this change only `watch ENOENT` would be printed.
