### PR TITLE
Embed full file path in results

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/krisselden/broccoli-sane-watcher",
   "dependencies": {
     "rsvp": "~3.0.8",
-    "sane": "~0.5.1",
+    "sane": "~0.6.0",
     "broccoli": "~0.12.2"
   },
   "devDependencies": {


### PR DESCRIPTION
In order for ember-cli's livereload to know the full file path
broccoli-sane-watcher needs to pass back that filePath in the results
hash. sane-0.6.0 has been updated to provide the root of the file path.
