### PR TITLE
Provide information about which files changed in the results hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,14 @@ function Watcher(builder, options) {
   this.watched = {};
   this.timeout = null;
   this.sequence = this.build();
+  this.changes = [];
 }
 
 Watcher.prototype = Object.create(EventEmitter.prototype);
 
 // gathers rapid changes as one build
 Watcher.prototype.scheduleBuild = function (filePath) {
+  this.changes.push(filePath);
   if (this.timeout) return;
 
   // we want the timeout to start now before we wait for the current build
@@ -48,8 +50,10 @@ Watcher.prototype.build = function Watcher_build(filePath) {
     .build(addWatchDir)
     .then(function(hash) {
       hash.filePath = filePath;
+      hash.changes = this.changes;
+      this.changes = [];
       return triggerChange(hash);
-    }, triggerError)
+    }.bind(this), triggerError)
     .then(function(run) {
       if (this.options.verbose) {
         printSlowTrees(run.graph);

--- a/tests/index.js
+++ b/tests/index.js
@@ -119,4 +119,32 @@ describe('broccoli-sane-watcher', function (done) {
       done();
     });
   });
+
+  it('should include the full file system paths of all changed files in the results hash', function(done) {
+    fs.mkdirSync('tests/fixtures/a');
+    var changes = 0;
+    var filter = new TestFilter(['tests/fixtures/a'], function () {
+      return 'output';
+    });
+    var builder = new broccoli.Builder(filter);
+    watcher = new Watcher(builder);
+    watcher.on('change', function (results) {
+      if (changes++) {
+        assert.equal(path.relative(process.cwd(), results.filePath), 'tests/fixtures/a/file-1.js');
+        assert.equal(results.changes.length, 2, 'results hash contains two changes');
+        assert.equal(path.relative(process.cwd(), results.changes[0]), 'tests/fixtures/a/file-1.js');
+        assert.equal(path.relative(process.cwd(), results.changes[1]), 'tests/fixtures/a/file-2.js');
+        done();
+      } else {
+        fs.writeFileSync('tests/fixtures/a/file-1.js');
+        fs.writeFileSync('tests/fixtures/a/file-2.js');
+      }
+    });
+
+    watcher.on('error', function (error) {
+      assert.ok(false, error.message);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
This PR provides a list of the files that were changed in the `change` event. This allows me to tell LiveReload to reload the CSS without reloading the whole page when only CSS files have changed. I'll be sending a PR to add this to ember-cli once this PR is merged.
