### PR TITLE
Allow regex-wise selection of files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = Watcher;
 function Watcher(builder, options) {
   this.builder = builder;
   this.options = options || {};
+  this.options.filter = this.options.filter || function(name) { return /^[^\.]/.test(name); };
   this.watched = {};
   this.timeout = null;
   this.sequence = this.build();
@@ -80,20 +81,18 @@ Watcher.prototype.addWatchDir = function Watcher_addWatchDir(dir) {
   this.watched[dir] = watcher;
 };
 
-Watcher.prototype.onFileChanged = function (filePath, root) {
-  if (this.options.verbose) console.log('file changed', filePath);
-  this.scheduleBuild(path.join(root, filePath));
-};
+function makeOnChanged (log) {
+  return function (filePath, root) {
+    if (this.options.filter(path.basename(filePath))) {
+      if (this.options.verbose) console.log(log, filePath);
+      this.scheduleBuild(path.join(root, filePath));
+    }
+  };
+}
 
-Watcher.prototype.onFileAdded = function (filePath, root) {
-  if (this.options.verbose) console.log('file added', filePath);
-  this.scheduleBuild(path.join(root, filePath));
-};
-
-Watcher.prototype.onFileDeleted = function (filePath, root) {
-  if (this.options.verbose) console.log('file deleted', filePath);
-  this.scheduleBuild(path.join(root, filePath));
-};
+Watcher.prototype.onFileChanged = makeOnChanged('file changed');
+Watcher.prototype.onFileAdded = makeOnChanged('file added');
+Watcher.prototype.onFileDeleted = makeOnChanged('file deleted');
 
 Watcher.prototype.triggerChange = function (hash) {
   this.emit('change', hash);

--- a/tests/index.js
+++ b/tests/index.js
@@ -147,4 +147,31 @@ describe('broccoli-sane-watcher', function (done) {
     });
   });
 
+  it('should only see files that the filter authorizes', function(done) {
+    fs.mkdirSync('tests/fixtures/a');
+    var changes = 0;
+    var filter = new TestFilter(['tests/fixtures/a'], function () {
+      return 'output';
+    });
+    var builder = new broccoli.Builder(filter);
+    var filter = function(name) { return /file-1/.test(name); };
+    watcher = new Watcher(builder, {filter: filter});
+    watcher.on('change', function (results) {
+      if (changes++) {
+        results.changes.forEach(function(change) {
+          assert(filter(change), 'changed file respects the filter');
+        });
+        done();
+      } else {
+        fs.writeFileSync('tests/fixtures/a/file-1.js');
+        fs.writeFileSync('tests/fixtures/a/file-2.js');
+      }
+    });
+
+    watcher.on('error', function (error) {
+      assert.ok(false, error.message);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
There is clearly interest in ignoring certain files from the watcher: https://github.com/stefanpenner/ember-cli/issues/2329.
Indeed, certain files such as vim's (and emacs') save files such as `.swp`, or `.DS_Store` files on MacOS X machines, will trigger extra rebuilds from ember-cli at an alarming rate.

This patch is a first step towards allowing restrictions on which files trigger a rebuild in ember-cli.
