### PR TITLE
failing test due to closing the watcher (only with watchman)

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -39,6 +39,23 @@ describe('broccoli-sane-watcher', function (done) {
     });
   });
 
+  it('should pass watchman option to sane', function () {
+    fs.mkdirSync('tests/fixtures/a');
+    var filter = new TestFilter(['tests/fixtures/a'], function () {
+      return 'output';
+    });
+    var builder = new broccoli.Builder(filter);
+
+    watcher = new Watcher(builder, {
+      watchman: true
+    });
+
+    return watcher.sequence.then(function () {
+      assert.ok(watcher.watched['tests/fixtures/a'] instanceof sane.WatchmanWatcher);
+    });
+  });
+
+
   it('should emit change event when file is added', function (done) {
     fs.mkdirSync('tests/fixtures/a');
 


### PR DESCRIPTION
- [ ] fix failure, although i think it is sane related.

```
  1) broccoli-sane-watcher should emit change event when file is added:
     Uncaught Error: The client was ended
      at Client.cancelCommands (/Users/stefan/src/broccoli-sane-watcher/node_modules/sane/node_modules/fb-watchman/index.js:41:15)
      at Client.end (/Users/stefan/src/broccoli-sane-watcher/node_modules/sane/node_modules/fb-watchman/index.js:170:8)
      at Object.onUnsubscribe [as cb] (/Users/stefan/src/broccoli-sane-watcher/node_modules/sane/src/watchman_watcher.js:181:17)
      at null.<anonymous> (/Users/stefan/src/broccoli-sane-watcher/node_modules/sane/node_modules/fb-watchman/index.js:88:15)
      at emit (events.js:107:17)
      at readableAddChunk (_stream_readable.js:162:16)
      at Readable.push (_stream_readable.js:125:10)
      at Transform.push (_stream_transform.js:140:32)
      at JSONStream._transform (/Users/stefan/src/broccoli-sane-watcher/node_modules/sane/node_modules/fb-watchman/node_modules/json-stream/lib/json-stream.js:30:14)
      at Transform._read (_stream_transform.js:179:10)
      at Transform._write (_stream_transform.js:167:12)
      at doWrite (_stream_writable.js:265:12)
      at writeOrBuffer (_stream_writable.js:252:5)
      at Writable.write (_stream_writable.js:197:11)
      at Socket.ondata (_stream_readable.js:539:20)
      at Socket.emit (events.js:107:17)
      at readableAddChunk (_stream_readable.js:162:16)
      at Socket.Readable.push (_stream_readable.js:125:10)
      at Pipe.onread (net.js:514:20)
```

cc @amasad: after reviewing sane tests i am surprised they don't also run into this... maybe Im doing something funky here, got time to check it out?