### PR TITLE
Use sane ready event. Fixes #21

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,12 +91,16 @@ Watcher.prototype.addWatchDir = function Watcher_addWatchDir(dir) {
   }
 
   var watcher = new sane(dir, this.options);
+  this.watched[dir] = watcher;
 
   watcher.on('change', this.onFileChanged.bind(this));
   watcher.on('add', this.onFileAdded.bind(this));
   watcher.on('delete', this.onFileDeleted.bind(this));
 
-  this.watched[dir] = watcher;
+  return new Promise(function(resolve, reject) {
+    watcher.on('error', reject);
+    watcher.on('ready', resolve);
+  });
 };
 
 function makeOnChanged (log) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -39,6 +39,22 @@ describe('broccoli-sane-watcher', function (done) {
     });
   });
 
+  it('should pass watchman option to sane', function () {
+    fs.mkdirSync('tests/fixtures/a');
+    var filter = new TestFilter(['tests/fixtures/a'], function () {
+      return 'output';
+    });
+    var builder = new broccoli.Builder(filter);
+
+    watcher = new Watcher(builder, {
+      watchman: true
+    });
+
+    return watcher.sequence.then(function () {
+      assert.ok(watcher.watched['tests/fixtures/a'] instanceof sane.WatchmanWatcher);
+    });
+  });
+
   it('should emit change event when file is added', function (done) {
     fs.mkdirSync('tests/fixtures/a');
 


### PR DESCRIPTION
Sane uses the clock command to initiate watchman and emit the `ready` event when it's ready to be used. This PR gets broccoli-sane-watcher to use the ready event.
